### PR TITLE
Fix gogs issues

### DIFF
--- a/cicd-template.yaml
+++ b/cicd-template.yaml
@@ -339,15 +339,19 @@ objects:
             GOGS_HOSTNAME="gogs-$CICD_NAMESPACE.$HOSTNAME"
 
             if [ "${EPHEMERAL}" == "true" ] ; then
-            curl -s https://raw.githubusercontent.com/OpenShiftDemos/gogs-openshift-docker/master/openshift/gogs-template.yaml|sed 's#sql\:9.5#sql\:9.6#g'| oc new-app -f - \
+            curl -s https://raw.githubusercontent.com/OpenShiftDemos/gogs-openshift-docker/master/openshift/gogs-template.yaml| oc process -f - \
                   --param=GOGS_VERSION=0.11.34 \
                   --param=HOSTNAME=$GOGS_HOSTNAME \
-                  --param=SKIP_TLS_VERIFY=true
+                  --param=DATABASE_VERSION=10 \
+                  --param=SKIP_TLS_VERIFY=true \
+            | oc apply -f -
             else
-            curl -s https://raw.githubusercontent.com/OpenShiftDemos/gogs-openshift-docker/master/openshift/gogs-persistent-template.yaml |sed 's#sql\:9.5#sql\:9.6#g'| oc new-app -f - \
+            curl -s https://raw.githubusercontent.com/OpenShiftDemos/gogs-openshift-docker/master/openshift/gogs-persistent-template.yaml | oc process -f - \
                   --param=GOGS_VERSION=0.11.34 \
                   --param=HOSTNAME=$GOGS_HOSTNAME \
-                  --param=SKIP_TLS_VERIFY=true
+                  --param=DATABASE_VERSION=10 \
+                  --param=SKIP_TLS_VERIFY=true \
+            | oc apply -f -
             fi
             
             sleep 5
@@ -384,21 +388,23 @@ objects:
             GOGS_USER=gogs
             GOGS_PWD=gogs
 
-            oc rollout status dc gogs
-
-            _RETURN=$(curl -o /tmp/curl.log -sL --post302 -w "%{http_code}" http://$GOGS_SVC:3000/user/sign_up \
+            echo -n "Waiting for gogs to come up..."
+            while true; do
+              _RETURN=$(curl -o /tmp/curl.log -sL --post302 -w "%{http_code}" http://$GOGS_SVC:3000/user/sign_up \
               --form user_name=$GOGS_USER \
               --form password=$GOGS_PWD \
               --form retype=$GOGS_PWD \
               --form email=admin@gogs.com)
-
-            sleep 5
-
-            if [ $_RETURN != "200" ] && [ $_RETURN != "302" ] ; then
-              echo "ERROR: Failed to create Gogs admin"
-              cat /tmp/curl.log
-              exit 255
-            fi
+              if [ "$_RETURN" = "200" ] || [ "$_RETURN" = "302" ]; then
+                echo "done"
+                break
+              fi
+              if [ "$_RETURN" = "503" ]; then
+                oc delete $(oc get po -o name | grep gogs | grep -v gogs-postgresql)
+              fi
+              echo -n "."
+              sleep 5
+            done
 
             sleep 10
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+cd `dirname $0`
+BASE=`pwd`
+cd - >> /dev/null
+
 echo "###############################################################################"
 echo "#  MAKE SURE YOU ARE LOGGED IN:                                               #"
 echo "#  $ oc login http://console.your.openshift.com                               #"
@@ -173,7 +177,7 @@ function deploy() {
 
   sleep 2
 
-  local template=https://raw.githubusercontent.com/$GITHUB_ACCOUNT/openshift-cd-demo/$GITHUB_REF/cicd-template.yaml
+  local template=${BASE}/../cicd-template.yaml
   echo "Using template $template"
   oc $ARG_OC_OPS new-app -f $template -p DEV_PROJECT=dev-$PRJ_SUFFIX -p STAGE_PROJECT=stage-$PRJ_SUFFIX -p DEPLOY_CHE=$ARG_DEPLOY_CHE -p EPHEMERAL=$ARG_EPHEMERAL -p ENABLE_QUAY=$ARG_ENABLE_QUAY -p QUAY_USERNAME=$ARG_QUAY_USER -p QUAY_PASSWORD=$ARG_QUAY_PASS -n cicd-$PRJ_SUFFIX 
 }


### PR DESCRIPTION
We conducted an ARO workshop today and could not complete Lab 3.

This was because of 2 issues:
1. gogs-postgresql would not come up due to a missing image - this was fixed by using version 10 instead of version 9.6
2. the cicd-demo-installer job would fail while trying to create the gogs user; this was fixed by putting the user creation curl request in a loop and exiting the loop only when the user creation succeeded; sometimes gogs would return a 503 error during user creation - this was fixed by killing the pod and letting a new instance spin up